### PR TITLE
Create a new custodian per connection

### DIFF
--- a/net/rfc6455/private/connection-manager.rkt
+++ b/net/rfc6455/private/connection-manager.rkt
@@ -20,5 +20,5 @@
 ;; InputPort OutputPort -> WebServerConnection
 (define (new-web-server-connection ip op)
   (if new-style-connection-manager?
-      (new-connection the-connection-manager (ws-idle-timeout) ip op (current-custodian) #f)
-      (new-connection (ws-idle-timeout) ip op (current-custodian) #f)))
+      (new-connection the-connection-manager (ws-idle-timeout) ip op (make-custodian) #f)
+      (new-connection (ws-idle-timeout) ip op (make-custodian) #f)))


### PR DESCRIPTION
Using the current custodian causes the main thread to be killed after `ws-idle-timeout`. Creating a new custodian per connection fixes this.
